### PR TITLE
Fixes delay param to proper type and converts to milliseconds

### DIFF
--- a/jewelbots_nRF51822_board_v100/cores/JWB_nRF51822/LED.cpp
+++ b/jewelbots_nRF51822_board_v100/cores/JWB_nRF51822/LED.cpp
@@ -31,13 +31,13 @@ uint8_t color_values[2];
 
 
 
-  void LED::on(uint8_t number, char *color, uint8_t length)  {
+  void LED::on(uint8_t number, char *color, uint32_t length)  {
     enable_led();
     clear_led();
     color_lookup(color);
     led_cmd_t options[4] = {number, color_values[0], color_values[1], color_values[2], 1};
     set_led_state_handler(options);
-    nrf_delay_us(length);
+    nrf_delay_us(length * 1000);
     clear_led();
   }
 

--- a/jewelbots_nRF51822_board_v100/cores/JWB_nRF51822/LED.h
+++ b/jewelbots_nRF51822_board_v100/cores/JWB_nRF51822/LED.h
@@ -13,7 +13,7 @@ class LED {
 public:
   LED();
   ~LED();
-  void on(uint8_t number, char *color, uint8_t length);
+  void on(uint8_t number, char *color, uint32_t length);
   void color_lookup(char *color);
 
 };


### PR DESCRIPTION
Fix for #11 

`uint32_t` is the proper type for the `nrf_delay_us` function. This change prevents the value from being corrupted during type conversion. Also this change converts the value from milliseconds to microseconds, so that the public API aligns with the Jewelbots API documentation.

With this change, this example will now work yielding an LED change every second.

```
#include <Arduino.h>

LED led;

void setup() {
}

void loop() {
  uint32_t delay = 1000;
  led.on(1, "magenta", delay);
  led.on(1, "red", delay);
}
```