### PR TITLE
Changed setLight from private to public

### DIFF
--- a/jewelbots_nRF51822_board_v100/cores/JWB_nRF51822/LED.h
+++ b/jewelbots_nRF51822_board_v100/cores/JWB_nRF51822/LED.h
@@ -21,8 +21,6 @@ public:
   void turnOn(LED_Pos led, ColorLabel color );
   void turnOff(LED_Pos led);
   void flash(LED_Pos led, ColorLabel color, uint8_t microseconds);
-
-private:
   void setLight(uint8_t number, uint8_t r, uint8_t g, uint8_t b);
 
 };


### PR DESCRIPTION
I'd like to be able to use any RGB value on an LED but didn't see a way to do so w/the public API in the LED library. This is a teensy change to move the `setLight` function out of private scope.

Additionally, how do I test my work, build the firmware, etc? Any guidance here is welcomed, thanks!